### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
     buildx:
-      runs-on: ubuntu-latest
+      runs-on: self-hosted
       steps:
         -
           name: Checkout

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       steps:
         -
           name: Checkout
-          uses: actions/checkout@v4.1.6
+          uses: actions/checkout@v4.1.7
           with:
             # [Required] Access token with `workflow` scope.
             token: ${{ secrets.WORKFLOW_SECRET }}
@@ -46,7 +46,7 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}          
         -
           name: Build and push
-          uses: docker/build-push-action@v5.3.0
+          uses: docker/build-push-action@v6.2.0
           with:
             context: .
             platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/riscv64,linux/s390x


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v6.2.0](https://github.com/docker/build-push-action/releases/tag/v6.2.0)** on 2024-06-26T13:09:11Z
